### PR TITLE
docs: Remove deprecated `kubectl` flag & refresh Killer Koda link to K8s scenario

### DIFF
--- a/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
+++ b/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
@@ -10,7 +10,7 @@ called "Killer Koda". This provides us with a playground for kubernetes with kub
 
 To get started,
 - Head over to [Killer Koda](https://killercoda.com/kubernetes/scenario/a-playground) to provision a demo playground.
-- Confirm kubectl and kustomize is installed and versions with the following command: `kubectl version --short`
+- Confirm kubectl and kustomize is installed and versions with the following command: `kubectl version`
 
 Clone the github repository:
 ```sh 

--- a/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
+++ b/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
@@ -9,7 +9,7 @@ So, we are NOT going to installing kubectl or kustomize yet, instead we will be 
 called "Killer Koda". This provides us with a playground for kubernetes with kubectl already installed. 
 
 To get started,
-- Head over to [Killer Koda](https://killercoda.com/kubernetes/scenario/a-playground) to provision a demo playground.
+- Head over to [Killer Koda](https://killercoda.com/playgrounds/scenario/kubernetes) to provision a demo playground.
 - Confirm kubectl and kustomize is installed and versions with the following command: `kubectl version`
 
 Clone the github repository:

--- a/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
+++ b/1. Welcome - Getting Started/what-is-kustomize/hands-on.md
@@ -9,7 +9,7 @@ So, we are NOT going to installing kubectl or kustomize yet, instead we will be 
 called "Killer Koda". This provides us with a playground for kubernetes with kubectl already installed. 
 
 To get started,
-- Head over to (Killer Koda)[https://killercoda.com/kubernetes/scenario/a-playground] to provision a demo playground.
+- Head over to [Killer Koda](https://killercoda.com/kubernetes/scenario/a-playground) to provision a demo playground.
 - Confirm kubectl and kustomize is installed and versions with the following command: `kubectl version --short`
 
 Clone the github repository:


### PR DESCRIPTION
@galonge, as time goes by and things tend to go out of date, here are a few refinements to keep things fresh:
- [x] Fix markdown link syntax.
- [x] Remove deprecated `--short` flag.
- [x] Fix link to Killer Koda K8s scenario.